### PR TITLE
修复查询日志 domain 筛选：默认使用 contains，支持 startsWith/endsWith 传参

### DIFF
--- a/src/components/dashboard/query-log/query-log-table.tsx
+++ b/src/components/dashboard/query-log/query-log-table.tsx
@@ -268,7 +268,7 @@ function TableQueryLogs(): React.JSX.Element {
     useState<MRTColumnFilterFnsState>(
       () => Object.fromEntries(
         columns.map(({ accessorKey }) => {
-          return [accessorKey, 'equals'];
+          return [accessorKey, accessorKey === 'domain' ? 'contains' : 'equals'];
         })
       ) as MRTColumnFilterFnsState
     );
@@ -412,7 +412,7 @@ function TableQueryLogs(): React.JSX.Element {
 
         const filterMode = columnFilterFns[filter.id];
         if (filter.id === 'domain') {
-          const supportedModes = ['contains', 'equals', 'notEmpty', 'startwith', 'endwith'];
+          const supportedModes = ['contains', 'equals', 'notEmpty', 'startsWith', 'endsWith'];
           if (supportedModes.includes(filterMode)) {
             queryParam['domain_filter_mode'] = filterMode as string;
           }
@@ -637,7 +637,10 @@ function TableQueryLogs(): React.JSX.Element {
         children: errorMsg,
       }
       : undefined,
-    onColumnFilterFnsChange: setColumnFilterFns,
+    onColumnFilterFnsChange: (updaterOrValue) => {
+      pageCursor.current = null;
+      setColumnFilterFns(updaterOrValue);
+    },
     onColumnFiltersChange: (filters) => {
       pageCursor.current = null;
       setColumnFilters(filters);


### PR DESCRIPTION
### Motivation
- 让查询日志表格中 `domain` 列的筛选默认模式更符合用户习惯，改为 `contains`；
- 当用户选择“开头为”“结尾为”时需要把相应模式正确地传递给后端；
- 筛选模式变更时应重置基于游标的分页以避免使用过期游标请求错误页。

### Description
- 将 `columnFilterFns` 的初始值调整为：`domain` 列默认为 `contains`，其它列仍为 `equals`（修改文件 `src/components/dashboard/query-log/query-log-table.tsx`）。
- 修正对可支持的 domain 筛选模式的校验字符串，把 `startwith`/`endwith` 改为 `startsWith`/`endsWith`，以便正确将 `domain_filter_mode` 传给后端（修改文件 `src/components/dashboard/query-log/query-log-table.tsx`）。
- 在 `onColumnFilterFnsChange` 回调中清空分页游标并更新筛选模式以避免旧游标影响请求（修改文件 `src/components/dashboard/query-log/query-log-table.tsx`）。

### Testing
- 运行 `npm run lint`，结果通过且无新增 ESLint 错误；
- 运行 `npm run typecheck`（`tsc --noEmit`），类型检查通过。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a2cdb65e48326bc4ba8b6cf9b0aa1)